### PR TITLE
Fix account.create[Tx] function calls

### DIFF
--- a/test-e2e/src/zp.ts
+++ b/test-e2e/src/zp.ts
@@ -139,10 +139,8 @@ export async function deposit(account: UserAccount, from: string, amount: string
   await token.methods.approve(zpAddress, amounBN.mul(denominator)).send({ from })
   console.log('Making a deposit...')
   const deposit: IDepositData = {
-    base_fields: {
-      fee: '0',
-      data: empty_data,
-    },
+    fee: '0',
+    data: empty_data,
     amount,
   }
   const mergeTx = await account.createDeposit(deposit)
@@ -157,10 +155,8 @@ export async function deposit(account: UserAccount, from: string, amount: string
 export async function transfer(account: UserAccount, to: string, amount: string, fake = false) {
   console.log('Making a transfer...')
   const transfer: ITransferData = {
-    base_fields: {
-      fee: '0',
-      data: empty_data,
-    },
+    fee: '0',
+    data: empty_data,
     outputs: [{ to, amount }]
   }
   const mergeTx = await account.createTransfer(transfer)
@@ -171,10 +167,8 @@ export async function transfer(account: UserAccount, to: string, amount: string,
 export async function withdraw(account: UserAccount, to: Uint8Array, amount: string, energy_amount: string, fake = false) {
   console.log('Making a withdraw...')
   const withdraw: IWithdrawData = {
-    base_fields: {
-      fee: '0',
-      data: empty_data
-    },
+    fee: '0',
+    data: empty_data,
     amount,
     to,
     native_amount: '0',


### PR DESCRIPTION
I've flattened the arguments of createDeposit, createTransfer, and createWithdraw here:
zeropoolnetwork/libzeropool-rs@cf0c2e10e3ffab93246b2693d93f1d462e0fe232