### PR TITLE
API improvements

### DIFF
--- a/zp-relayer/endpoints.ts
+++ b/zp-relayer/endpoints.ts
@@ -41,8 +41,8 @@ async function merkleRoot(req: Request, res: Response) {
 }
 
 async function getTransactions(req: Request, res: Response) {
-  const limit = parseInt(req.params.limit)
-  const offset = parseInt(req.params.offset)
+  const limit = parseInt(req.query.limit as string || '100')
+  const offset = parseInt(req.query.offset as string || '0')
   const txs = await pool.getTransactions(limit, offset)
   res.json(txs)
 }

--- a/zp-relayer/index.ts
+++ b/zp-relayer/index.ts
@@ -29,7 +29,7 @@ const router = express.Router()
 router.post('/proof_tx', endpoints.txProof)
 
 router.post('/transaction', endpoints.transaction)
-router.get('/transactions/:limit(\\d+)/:offset(\\d+)', endpoints.getTransactions)
+router.get('/transactions', endpoints.getTransactions)
 router.get('/merkle/root/:index?', endpoints.merkleRoot)
 router.get('/job/:id', endpoints.getJob)
 router.get('/info', endpoints.relayerInfo)

--- a/zp-relayer/pool.ts
+++ b/zp-relayer/pool.ts
@@ -220,14 +220,14 @@ class Pool {
 
   async getTransactions(limit: number, offset: number) {
     await this.syncState()
-    const txs: (string | null)[] = new Array(limit)
-    offset = Math.ceil(offset / OUTPLUSONE)
+    const txs: string[] = []
+    offset = Math.floor(offset / OUTPLUSONE) * OUTPLUSONE
     for (let i = 0; i < limit; i++) {
       const tx = this.txs.get(offset + i * OUTPLUSONE)
       if (tx) {
         txs[i] = tx.toString('hex')
       } else {
-        txs[i] = null
+        break;
       }
     }
     return txs


### PR DESCRIPTION
1. The limit/offset interface in most cases is implemented using query parameters. The previous way was unintuitive and prone to errors.
2. Also fixed the behaviour of the /transactions endpoint: the offset parameter did not work at all and the resulting array was filled with useless nulls.